### PR TITLE
Django 1.11 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=find_packages(),
 
     install_requires=(
-        'Django>=1.8',
+        'Django>=1.11',
         'monkeypatch==0.1rc3',
     ),
 )


### PR DESCRIPTION
New style middleware introduced in Django 1.11

Docs: https://docs.djangoproject.com/en/2.1/releases/1.10/#new-style-middleware

If support for Django<1.11 needs to preserved, then this requires some more work.